### PR TITLE
Add Shouyou Plus schema option

### DIFF
--- a/Windows/PowerShell/按需下载万象方案-词库-模型-utf-8.ps1
+++ b/Windows/PowerShell/按需下载万象方案-词库-模型-utf-8.ps1
@@ -26,8 +26,8 @@ function Exit-Tip {
     exit $exitCode
 }
 
-if ($auto -and (-not $schemaType -or $schemaType -notmatch '^[0-7]$')) {
-    Write-Host "错误：自动模式下必须通过 -schemaType 指定方案类型编号（0-7），如 -schemaType 6" -ForegroundColor Red
+if ($auto -and (-not $schemaType -or $schemaType -notmatch '^[0-8]$')) {
+    Write-Host "错误：自动模式下必须通过 -schemaType 指定方案类型编号（0-8），如 -schemaType 6" -ForegroundColor Red
     Exit-Tip 1
 }
 
@@ -35,14 +35,14 @@ if ($help -or $args -contains '-h' -or $args -contains '--help') {
     # 仅在非 help 模式下强制要求 schemaType
     if (-not $help -and -not ($args -contains '-h') -and -not ($args -contains '--help')) {
         if (-not $schemaType) {
-            Write-Host "错误：-schemaType 参数为必填项，请指定方案类型编号（0-7）。" -ForegroundColor Red
+            Write-Host "错误：-schemaType 参数为必填项，请指定方案类型编号（0-8）。" -ForegroundColor Red
             Write-Host "示例：pwsh -File .\\按需下载万象方案-词库-模型-utf-8.ps1 -schemaType 6"
             Exit-Tip 1
         }
     }
     Write-Host "Rime 万象 PowerShell 更新工具 - 命令行参数说明" -ForegroundColor Cyan
     Write-Host "---------------------------------------------"
-    Write-Host "-schemaType <编号>   方案类型编号，0-7 (如 6 表示自然码)"
+    Write-Host "-schemaType <编号>   方案类型编号，0-8 (如 6 表示自然码)"
     Write-Host "-noSchema            不更新方案"
     Write-Host "-noDict              不更新词库"
     Write-Host "-noModel             不更新模型"
@@ -75,7 +75,7 @@ $IsUpdateDictDown = $true
 $IsUpdateModel = $true
 
 # 设置自动更新时选择的方案，注意必须包含双引号，例如：$InputSchemaType = "0";
-# [0]-标准版; [1]-小鹤; [2]-汉心; [3]-墨奇; [4]-虎码; [5]-五笔; [6]-自然码; [7]-首右"
+# [0]-标准版; [1]-小鹤; [2]-汉心; [3]-墨奇; [4]-虎码; [5]-五笔; [6]-自然码; [7]-首右; [8]-首右plus
 $InputSchemaType = "6";
 
 # 设置自动更新时要跳过的文件列表，配置好后删除注释符号
@@ -203,7 +203,8 @@ $KeyTable = @{
     "4" = "tiger";
     "5" = "wubi";
     "6" = "zrm";
-    "7" = "shouyou"
+    "7" = "shouyou";
+    "8" = "shyplus"
 }
 
 $UriHeader = @{
@@ -212,7 +213,7 @@ $UriHeader = @{
     'Accept-Charset' = 'utf-8'
 }
 
-$SchemaDownloadTip = "[0]-标准版; [1]-小鹤; [2]-汉心; [3]-墨奇; [4]-虎码; [5]-五笔; [6]-自然码; [7]-首右";
+$SchemaDownloadTip = "[0]-标准版; [1]-小鹤; [2]-汉心; [3]-墨奇; [4]-虎码; [5]-五笔; [6]-自然码; [7]-首右; [8]-首右plus";
 
 $GramKeyTable = @{
     "0" = "zh-hans.gram";
@@ -801,9 +802,9 @@ $promptDictDown = "是否下载词库:`n[0]-下载; [1]-不下载"
 if ($AutoUpdate) {
     Write-Host "自动更新模式，将自动下载最新的版本" -ForegroundColor Green
     Write-Host "你配置的方案号为：$InputSchemaType" -ForegroundColor Green
-    # 方案号只支持0-7
-    if ($InputSchemaType -lt 0 -or $InputSchemaType -gt 7) {
-        Write-Error "错误：方案号只能是0-7"
+    # 方案号只支持0-8
+    if ($InputSchemaType -lt 0 -or $InputSchemaType -gt 8) {
+        Write-Error "错误：方案号只能是0-8"
         Exit-Tip 1
     }
     $InputAllUpdate = "0"


### PR DESCRIPTION
## Summary

- Add `[8]-首右plus` to the PowerShell schema selection menu.
- Map schema type `8` to the `shyplus` release asset key.
- Expand command-line and automatic-mode validation from `0-7` to `0-8`.
- Update the related help text and error messages.

## Why

The PowerShell updater supports the existing `shouyou` schema but is missing the corresponding Shouyou Plus option. Shouyou Plus uses the same update flow and only needs to select the `shyplus` release asset.

## Impact

Windows PowerShell users can select Shouyou Plus interactively or pass `-schemaType 8` in automatic mode.

## Validation

- `git diff --check`
- Confirmed schema type 8 is handled consistently by validation, prompts, range checks, and asset lookup.
- PowerShell parser validation was not run because `pwsh` is unavailable in the local environment.
